### PR TITLE
Two manufacturing widgets to aid in microrobot manufacturing

### DIFF
--- a/api_examples/test_tilepart_widget.py
+++ b/api_examples/test_tilepart_widget.py
@@ -1,0 +1,45 @@
+
+import qt.QtGui as qg
+import popupcad
+from popupcad_manufacturing_plugins.manufacturing.tilepart import TilePart
+import os
+import sys
+
+# file to load and work with
+myfolder  = '/Users/nickgravish/popupCAD_files/designs'
+design_file    = 'Transmissions.cad' #'robobee_interference_hinge.cad'
+
+if __name__=='__main__':
+
+    app = qg.QApplication(sys.argv)
+
+    design = popupcad.filetypes.design.Design.load_yaml(os.path.join(myfolder, design_file))
+    design.reprocessoperations(debugprint=True) ## IMPORTANT
+    #part_opref, sheet_opref, sketch_bounding_box, N, scale, x_gap, y_gap, support_offset
+
+    release = design.operations[-3].id
+    part_opref = design.operations[-2].id
+    sheet_opref = design.operations[-1].id
+    sketch_id = 4762336016  #4751474000
+
+    scaling = popupcad.csg_processing_scaling
+    sketch_bounding_box = design.sketches[sketch_id].output_csg()[0].bounds # may break if multiple sketches
+    sketch_bounding_box = [geom/scaling for geom in sketch_bounding_box]
+
+    N = 10
+    scale = 1.
+    x_gap = 0.
+    y_gap = 0.
+    support_offset = 0.
+
+    new = TilePart(part_opref, release, sheet_opref, sketch_bounding_box, N, scale, x_gap, y_gap, support_offset)
+
+    design.addoperation(new)
+    new.operate(design)
+
+    ################## show the new design
+
+    editor = popupcad.guis.editor.Editor()
+    editor.load_design(design)
+    editor.show()
+    sys.exit(app.exec_())

--- a/popupcad_manufacturing_plugins/__init__.py
+++ b/popupcad_manufacturing_plugins/__init__.py
@@ -4,7 +4,7 @@ Written by Daniel M. Aukes and CONTRIBUTORS
 Email: danaukes<at>seas.harvard.edu.
 Please see LICENSE for full license.
 """
-
+from popupcad import manufacturing
 from . import manufacturing
 
 #import external modules
@@ -30,9 +30,13 @@ def build_menu_system(program):
         program.editor.newoperation(manufacturing.identifybodies2.IdentifyBodies2)
     def new_identify_rigid_bodies():
         program.editor.newoperation(manufacturing.identifyrigidbodies2.IdentifyRigidBodies2)
+    def new_alignment_layup():
+        program.editor.newoperation(manufacturing.generatealignmentlayup.AlignmentLayup)
+    def new_tile_part():
+        program.editor.newoperation(manufacturing.tilepart.TilePart)
 
     action_definitions = {}
-    
+
     action_definitions['sheet']={'text': 'Sheet','icon': 'outersheet'}
     action_definitions['web']={'text': '&Web','icon': 'outerweb' }
     action_definitions['scrap']={'text': 'Scrap','icon': 'scrap'}
@@ -46,21 +50,26 @@ def build_menu_system(program):
     action_definitions['removability']={'text': 'Removability','icon': 'removability'}
     action_definitions['identify_bodies']={'text': 'Identify Bodies','icon': 'identifybodies'}
 
+    action_definitions['alignment_layup']={'text': 'Alignment layup','icon': 'identifybodies'}
+    action_definitions['tile_part']={'text': 'Tile parts','icon': 'identifybodies'}
+
     toolbar_definitions={}
     toolbar_definitions['Scrap']={'text': 'Scrap', 'icon': 'scrap'}
     toolbar_definitions['Support']={'text': 'Support','icon': 'outerweb'}
     toolbar_definitions['Misc']={'text': 'Misc...','icon': 'dotdotdot'}
+    toolbar_definitions['Microrobotics']={'text': 'Microrobotics','icon': 'dotdotdot'}
 
     menu_structure = {}
-    menu_structure['manufacturing'] = ['Scrap','Support','identify_bodies','Misc']
+    menu_structure['manufacturing'] = ['Scrap','Support','identify_bodies','Misc','Microrobotics']
     menu_structure['top'] = ['manufacturing']
     menu_structure['Scrap'] = ['sheet','web','scrap']
     menu_structure['Support'] = ['support_action','custom_support']
     menu_structure['Misc'] = ['keepout','identify_rigid_bodies','removability']
-    
+    menu_structure['Microrobotics'] = ['alignment_layup', 'tile_part']
+
     toolbar_structure = menu_structure.copy()
     shortcuts = {}
-    
+
     triggered = {}
     triggered['sheet'] = new_sheet
     triggered['web'] = new_web
@@ -71,6 +80,8 @@ def build_menu_system(program):
     triggered['identify_rigid_bodies'] = new_identify_rigid_bodies
     triggered['removability'] = new_removability
     triggered['identify_bodies'] = new_identify_bodies
+    triggered['alignment_layup'] = new_alignment_layup
+    triggered['tile_part'] = new_tile_part
 
     for key,value in triggered.items():
         action_definitions[key]['triggered'] = value    

--- a/popupcad_manufacturing_plugins/__init__.py
+++ b/popupcad_manufacturing_plugins/__init__.py
@@ -4,7 +4,6 @@ Written by Daniel M. Aukes and CONTRIBUTORS
 Email: danaukes<at>seas.harvard.edu.
 Please see LICENSE for full license.
 """
-from popupcad import manufacturing
 from . import manufacturing
 
 #import external modules

--- a/popupcad_manufacturing_plugins/manufacturing/__init__.py
+++ b/popupcad_manufacturing_plugins/manufacturing/__init__.py
@@ -21,6 +21,8 @@ from . import outersheet3
 from . import removability2
 from . import scrapoperation2
 from . import supportcandidate4
+from . import generatealignmentlayup
+from . import tilepart
 #from . import identifyrigidbodies
 #from . import supportcandidate3
 #from . import toolclearance2

--- a/popupcad_manufacturing_plugins/manufacturing/generatealignmentlayup.py
+++ b/popupcad_manufacturing_plugins/manufacturing/generatealignmentlayup.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""
+Contributed by Nick Gravish
+Email: gravish<at>seas.harvard.edu.
+Please see LICENSE for full license.
+"""
+
+import popupcad
+from popupcad.manufacturing.multivalueoperation3 import MultiValueOperation3
+from popupcad.filetypes.sketch import Sketch
+from popupcad.manufacturing.sub_operation2 import SubOperation2
+from popupcad.filetypes.laminate import Laminate
+
+import numpy as np
+from popupcad.filetypes.operationoutput import OperationOutput
+
+class AlignmentLayup(MultiValueOperation3):
+    name = 'AlignmentLayup'
+    valuenames = ['Sheet width', 'Pin offset', 'Pin radius']
+    defaults = [25., 3., 0.79]
+    show = []
+
+    def operate(self, design):
+
+        """
+        Return a generic_laminate ref of a layup laminate with all the layers of the part and with the appropriate 25x25mm alignment
+        features compatible with the Wood lab micro-robotics manufacturing process.
+
+        Input:
+        Design -> a popupcad design file
+
+        Output:
+        layup -> A handle to the layup design file
+        subop -> A subop which is inserted into the input design file to reduce the number of operations
+        """
+
+
+        #### general geometry constants that most layups will have
+        sheet_width = self.values[0]        # mm
+        hole_offset = self.values[1]        # location of hole in from corner
+        hole_rad    = self.values[2]        # alignment pin geoms
+
+        cross_len   = .75                   # tick length
+        cross_horiz = sheet_width/2 - 2*cross_len        # horizontal dimension from center crosshair
+        dt          = 0.001                 # small thickness for crosshair
+
+        buff_x      = 5                     # for window sizes
+        buff_y      = 1
+        wind_h      = 1
+        space_x     = 1.3
+
+        # window width, maximum of 1 mm
+        wind_w      = lambda N: max(min((sheet_width - 2*buff_x)/(N + 1.3*N - 1.3), 1),0.01)
+
+        # the laminate design
+        layup = popupcad.filetypes.design.Design.new()
+        layup.updatefilename("layup")
+        layer_list = design.return_layer_definition().layers
+        layup.define_layers(popupcad.filetypes.layerdef.LayerDef(*layer_list))
+
+
+        # initiate the sketches
+        ############# sheet first
+        sheet = Sketch.new()
+        tmp_geom = [(-sheet_width/2., -sheet_width/2.), (-sheet_width/2.,  sheet_width/2.),
+                    ( sheet_width/2.,  sheet_width/2.), ( sheet_width/2., -sheet_width/2.)]
+        sheet_poly = popupcad.filetypes.genericshapes.GenericPoly.gen_from_point_lists(tmp_geom,[])
+        sheet.addoperationgeometries([sheet_poly])
+
+        ############# holes second
+        holes = Sketch.new()
+        tmp_geom = [(-sheet_width/2. + hole_offset, -sheet_width/2. + hole_offset),
+                    (-sheet_width/2. + hole_offset,  sheet_width/2. - hole_offset),
+                    ( sheet_width/2. - hole_offset,  sheet_width/2. - hole_offset),
+                    ( sheet_width/2. - hole_offset, -sheet_width/2. + hole_offset)]
+        # make list of hole geometry
+        holes_poly = [popupcad.filetypes.genericshapes.GenericCircle.gen_from_point_lists([pt, (pt[0]+hole_rad, pt[1])],[])
+                                            for pt in tmp_geom]
+        holes.addoperationgeometries(holes_poly)
+
+        ############# upper triangle
+        left_tri = Sketch.new()
+        tmp_geom = [(-sheet_width/2. + hole_offset/4, sheet_width/2. - hole_offset*(2/3)),
+                    (-sheet_width/2. + hole_offset/4 + hole_rad,  sheet_width/2. - hole_offset*(2/3)),
+                    (-sheet_width/2. + hole_offset/4 + 0.5*hole_rad,  sheet_width/2. - hole_offset*(2/3) + 1.2*hole_rad*.75)]
+        # make list of hole geometry
+        sheet_poly = popupcad.filetypes.genericshapes.GenericPoly.gen_from_point_lists(tmp_geom,[])
+        left_tri.addoperationgeometries([sheet_poly])
+
+        ############# crosshairs
+        cross_hairs = Sketch.new()
+        tmp_geom_horiz = [(0,-cross_len), (0,cross_len)]
+        tmp_geom_vert  = [(-cross_len,0), (cross_len,0)]
+        shift = [-cross_horiz, 0, cross_horiz]
+
+        cross_poly_horiz = [popupcad.filetypes.genericshapes.GenericPoly.gen_from_point_lists([(tmp_geom_horiz[0][0] + c - dt/2.,
+                                                                                                tmp_geom_horiz[0][1] - dt/2.),
+                                                                                               (tmp_geom_horiz[1][0] + c - dt/2.,
+                                                                                                tmp_geom_horiz[1][1] - dt/2.),
+                                                                                               (tmp_geom_horiz[1][0] + c + dt/2.,
+                                                                                                tmp_geom_horiz[1][1] + dt/2.),
+                                                                                               (tmp_geom_horiz[0][0] + c + dt/2.,
+                                                                                                tmp_geom_horiz[0][1] - dt/2.)],
+                                                                                               [])
+                                                                                        for c in shift]
+
+        cross_poly_vert  = [popupcad.filetypes.genericshapes.GenericPoly.gen_from_point_lists([(tmp_geom_vert[0][0] + c - dt/2.,
+                                                                                                tmp_geom_vert[0][1] - dt/2.),
+                                                                                               (tmp_geom_vert[1][0] + c - dt/2.,
+                                                                                                tmp_geom_vert[1][1] + dt/2.),
+                                                                                               (tmp_geom_vert[1][0] + c + dt/2.,
+                                                                                                tmp_geom_vert[1][1] + dt/2.),
+                                                                                               (tmp_geom_vert[0][0] + c + dt/2.,
+                                                                                                tmp_geom_vert[0][1] - dt/2.)],
+                                                                                               [])
+                                                                                        for c in shift]
+
+        cross_hairs.addoperationgeometries(cross_poly_horiz + cross_poly_vert)
+
+        # Build the sheet with holes
+        # Add the sketches to the sketch list
+        layup.sketches[sheet.id] = sheet
+        layup.sketches[holes.id] = holes
+        layup.sketches[cross_hairs.id] = cross_hairs
+        layup.sketches[left_tri.id] = left_tri
+
+        # get the layer links for making sketch ops
+        layer_links = [layer.id for layer in layer_list]
+
+        holes_sketch = popupcad.manufacturing.simplesketchoperation.SimpleSketchOp({'sketch': [holes.id]},layer_links)
+        holes_sketch .name = "Holes"
+
+        trian_sketch = popupcad.manufacturing.simplesketchoperation.SimpleSketchOp({'sketch': [left_tri.id]},layer_links)
+        trian_sketch .name = "Left triangle"
+
+        sheet_sketch = popupcad.manufacturing.simplesketchoperation.SimpleSketchOp({'sketch': [sheet.id]},layer_links)
+        sheet_sketch.name = "sheet"
+
+        cross_sketch = popupcad.manufacturing.simplesketchoperation.SimpleSketchOp({'sketch': [cross_hairs.id]},layer_links)
+        cross_sketch.name = "Crosshairs"
+
+        # laminate operation to combine cross hairs and holes
+        sheet_with_holes = popupcad.manufacturing.laminateoperation2.LaminateOperation2({'unary': [(sheet_sketch.id,0)],
+                                                                                         'binary': [(holes_sketch.id,0),
+                                                                                                    (cross_sketch.id,0),
+                                                                                                    (trian_sketch.id,0)]},
+                                                                                        'difference')
+        sheet_with_holes.name = "Sheet with holes"
+
+        ############# rectangle windows
+        windows = [Sketch.new() for _ in layer_list]
+        windows_sketchop = []
+        # make windows, center on middle of sheet at bottom
+        window_width = wind_w(len(windows))
+        window_coords = np.array([round(kk*(1 + space_x)*window_width,4) for kk in range(len(windows))])
+        window_coords = list(window_coords - np.mean(window_coords)) # center is 0
+
+        for kk, (layer, window, x_coord) in enumerate(zip(layer_list,
+                                                          windows,
+                                                          window_coords)):
+
+            window.name = layer.name + '_window'
+
+            tmp_geom = [(x_coord, -sheet_width/2. + buff_y),
+                        (x_coord,  -sheet_width/2. + buff_y + wind_h),
+                        (x_coord + window_width, -sheet_width/2. + buff_y + wind_h),
+                        (x_coord + window_width, -sheet_width/2. + buff_y)]
+            sheet_poly = popupcad.filetypes.genericshapes.GenericPoly.gen_from_point_lists(tmp_geom,[])
+            window.addoperationgeometries([sheet_poly])
+            layup.sketches[window.id] = window
+
+            # make a sketch op on all layers above the current layer, this will be removed with a difference from the sheet
+            windows_sketchop.append(popupcad.manufacturing.simplesketchoperation.SimpleSketchOp({'sketch': [window.id]},
+                                                                                       layer_links[kk+1:]))
+            windows_sketchop[-1].name = "Window_" + layer.name
+
+        # laminate operation to remove windows from sheet with holes
+        sheet_with_windows = popupcad.manufacturing.laminateoperation2.LaminateOperation2({'unary': [(sheet_with_holes.id,0)],
+                                                                                         'binary': [(sktch.id,0) for sktch
+                                                                                                    in windows_sketchop]},
+                                                                                         'difference')
+        sheet_with_windows.name = "Final sheet"
+
+        # add the sketch ops to the design and generate the sketch op
+        other_ops = windows_sketchop + [trian_sketch, holes_sketch, sheet_sketch, cross_sketch, sheet_with_holes, sheet_with_windows]
+        [layup.addoperation(item) for item in other_ops]
+        [item.generate(layup) for item in other_ops]
+
+        return sheet_with_windows.output[0].csg
+
+        # might need valueoperation

--- a/popupcad_manufacturing_plugins/manufacturing/generatealignmentlayup.py
+++ b/popupcad_manufacturing_plugins/manufacturing/generatealignmentlayup.py
@@ -53,7 +53,7 @@ class AlignmentLayup(MultiValueOperation3):
         wind_w      = lambda N: max(min((sheet_width - 2*buff_x)/(N + 1.3*N - 1.3), 1),0.01)
 
         # the laminate design
-        layup = popupcad.filetypes.design.Design.new()
+        layup = design # popupcad.filetypes.design.Design.new()
         layup.updatefilename("layup")
         layer_list = design.return_layer_definition().layers
         layup.define_layers(popupcad.filetypes.layerdef.LayerDef(*layer_list))
@@ -186,7 +186,7 @@ class AlignmentLayup(MultiValueOperation3):
         [layup.addoperation(item) for item in other_ops]
         [item.generate(layup) for item in other_ops]
 
-        self.output = [sheet_with_windows]
+        self.output = [OperationOutput(sheet_with_windows.output[0], "OutputLaminate", self)]
         return sheet_with_windows.output[0].csg
 
         # might need valueoperation

--- a/popupcad_manufacturing_plugins/manufacturing/generatealignmentlayup.py
+++ b/popupcad_manufacturing_plugins/manufacturing/generatealignmentlayup.py
@@ -54,10 +54,7 @@ class AlignmentLayup(MultiValueOperation3):
 
         # the laminate design
         layup = design # popupcad.filetypes.design.Design.new()
-        layup.updatefilename("layup")
         layer_list = design.return_layer_definition().layers
-        layup.define_layers(popupcad.filetypes.layerdef.LayerDef(*layer_list))
-
 
         # initiate the sketches
         ############# sheet first
@@ -185,6 +182,7 @@ class AlignmentLayup(MultiValueOperation3):
         other_ops = windows_sketchop + [trian_sketch, holes_sketch, sheet_sketch, cross_sketch, sheet_with_holes, sheet_with_windows]
         [layup.addoperation(item) for item in other_ops]
         [item.generate(layup) for item in other_ops]
+        [layup.remove_operation(item) for item in other_ops]
 
         self.output = [OperationOutput(sheet_with_windows.output[0], "OutputLaminate", self)]
         return sheet_with_windows.output[0].csg

--- a/popupcad_manufacturing_plugins/manufacturing/generatealignmentlayup.py
+++ b/popupcad_manufacturing_plugins/manufacturing/generatealignmentlayup.py
@@ -186,6 +186,7 @@ class AlignmentLayup(MultiValueOperation3):
         [layup.addoperation(item) for item in other_ops]
         [item.generate(layup) for item in other_ops]
 
+        self.output = [sheet_with_windows]
         return sheet_with_windows.output[0].csg
 
         # might need valueoperation

--- a/popupcad_manufacturing_plugins/manufacturing/tilepart.py
+++ b/popupcad_manufacturing_plugins/manufacturing/tilepart.py
@@ -10,6 +10,8 @@ Please see LICENSE for full license.
 # import sys
 # import numpy as np
 import math
+from platform import release
+
 import qt.QtGui as qg
 
 # from popupcad.filetypes.operationoutput import OperationOutput
@@ -27,6 +29,7 @@ from popupcad.manufacturing.multivalueoperation3 import MultiValueOperation3
 from popupcad.widgets.dragndroptree import DraggableTreeWidget
 from popupcad.widgets.listmanager import SketchListManager,SketchListViewer
 from popupcad.filetypes.operationoutput import OperationOutput
+from popupcad.filetypes.laminate import Laminate
 
 class Dialog(qg.QDialog):
 
@@ -36,8 +39,10 @@ class Dialog(qg.QDialog):
         if tilepart is not None:
 
             self.sheet_opref_tp = tilepart.sheet_opref
+            self.release_opref_tp = tilepart.release_opref
             self.part_opref_tp = tilepart.part_opref
             self.sketch_bounding_box_tp = tilepart.sketch_bounding_box
+            self.sketch_id_tp = tilepart.sketch_id
             self.sc_tp = tilepart.sc
             self.N_tp = tilepart.N
             self.x_gap_tp = tilepart.x_gap
@@ -46,8 +51,13 @@ class Dialog(qg.QDialog):
 
         else:
             # define defaults
-            self.sheet_opref_tp = None
-            self.part_opref_tp = None
+            self.sheet_opref_tp = None if len(design.operations) == 0 else design.operations[0].id
+            self.release_opref_tp = None if len(design.operations) == 0 else design.operations[0].id
+            self.part_opref_tp = None if len(design.operations) == 0 else design.operations[0].id
+
+            sketchids = [id for key, id in enumerate(design.sketches)]
+            self.sketch_id_tp = None if len(design.sketches) == 0 else design.sketches[sketchids[0]]
+
             self.sketch_bounding_box_tp = [(0,0),(0,0)]
             self.sc_tp = 1
             self.N_tp = 10
@@ -69,20 +79,19 @@ class Dialog(qg.QDialog):
 
         self.part = DraggableTreeWidget()
         self.part.linklist(prioroperations)
-        self.part.setObjectName("Operation to tile")
-        # self.part.setCurrentItem(design.operation_index(self.part_opref_tp))
+        # self.part.setCurrentItem()
+        self.part.selectIndeces([(design.operation_index(self.part_opref_tp), 0)])
 
         self.release = DraggableTreeWidget()
         self.release.linklist(prioroperations)
-        self.release.setObjectName("Release cut (optional)")
-        # self.part.setCurrentItem(design.operation_index(self.part_opref_tp))
+        self.release.selectIndeces([(design.operation_index(self.release_opref_tp), 0)])
 
         self.sketch_to_tile = SketchListManager(design,name = 'Sketch of tile area')
+        self.sketch_to_tile.refresh_list(selected_item = self.sketch_id_tp)
 
         self.sheet = DraggableTreeWidget()
         self.sheet.linklist(prioroperations)
-        self.sheet.setObjectName("Sheet to tile into")
-        # self.sheet.setCurrentItem(design.operation_index(self.sheet_opref_tp))
+        self.sheet.selectIndeces([(design.operation_index(self.sheet_opref_tp), 0)])
 
         #       operation/part | sketch to tile in | sheet to tile into
         layout_ops_sheet_sketch = qg.QHBoxLayout()
@@ -91,6 +100,29 @@ class Dialog(qg.QDialog):
         layout_ops_sheet_sketch.addWidget(self.sketch_to_tile)
         layout_ops_sheet_sketch.addWidget(self.sheet)
 
+        # layout_ops_sheet_sketch = qg.QHBoxLayout()
+        # part_vbox = qg.QVBoxLayout()
+        # part_vbox.addWidget(qg.QLabel('Part to tile'))
+        # part_vbox.addWidget(self.part)
+        # layout_ops_sheet_sketch.addLayout(part_vbox)
+        # layout_ops_sheet_sketch.addStretch()
+        #
+        # rel_vbox = qg.QVBoxLayout()
+        # rel_vbox.addWidget(qg.QLabel('Release cut (optional)'))
+        # rel_vbox.addWidget(self.release)
+        # layout_ops_sheet_sketch.addLayout(rel_vbox)
+        # layout_ops_sheet_sketch.addStretch()
+        #
+        # sktch_vbox = qg.QVBoxLayout()
+        # sktch_vbox.addWidget(self.sketch_to_tile)
+        # layout_ops_sheet_sketch.addLayout(sktch_vbox)
+        # layout_ops_sheet_sketch.addStretch()
+        #
+        # sht_vbox = qg.QVBoxLayout()
+        # sht_vbox.addWidget(qg.QLabel('Sheet to tile into'))
+        # sht_vbox.addWidget(self.release)
+        # layout_ops_sheet_sketch.addLayout(sht_vbox)
+
         #       'Number of parts', 'Scale'
         number_of_parts_and_scale = qg.QHBoxLayout()
 
@@ -98,13 +130,11 @@ class Dialog(qg.QDialog):
         number_of_parts_and_scale.addWidget(qg.QLabel('Number of parts'))
         self.N = qg.QLineEdit()
         number_of_parts_and_scale.addWidget(self.N)
-        self.N.setText(str(self.N_tp))
 
         number_of_parts_and_scale.addWidget(qg.QLabel('Scale'))
         self.scale = qg.QLineEdit()
         number_of_parts_and_scale.addWidget(self.scale)
         number_of_parts_and_scale.addStretch()
-        self.scale.setText(str(self.sc_tp))
 
         #                       'x-gap', 'y-gap'
         xy_gap = qg.QHBoxLayout()
@@ -112,12 +142,10 @@ class Dialog(qg.QDialog):
 
         xy_gap.addWidget(qg.QLabel('X-gap'))
         self.x_gap = qg.QLineEdit()
-        self.x_gap.setText(str(self.x_gap_tp))
         xy_gap.addWidget(self.x_gap)
 
         xy_gap.addWidget(qg.QLabel('Y-gap'))
         self.y_gap = qg.QLineEdit()
-        self.y_gap.setText(str(self.y_gap_tp))
         xy_gap.addWidget(self.y_gap)
         xy_gap.addStretch()
 
@@ -125,8 +153,6 @@ class Dialog(qg.QDialog):
         s_offset.addStretch()
         s_offset.addWidget(qg.QLabel('Support offset'))
         self.support_offset = qg.QLineEdit()
-        self.support_offset.setText(str(self.support_offset_tp))
-        s_offset.addWidget(self.support_offset)
         s_offset.addWidget(self.support_offset)
         s_offset.addStretch()
 
@@ -140,8 +166,15 @@ class Dialog(qg.QDialog):
         button2.clicked.connect(self.reject)
         buttons.addWidget(button2)
 
+        instructions = qg.QHBoxLayout()
+        instructions.addStretch()
+        instructions.addWidget(qg.QLabel("Part to tile | Release cut (optional) | "
+                                                               "Bounding box sketch | Sheet to tile into"))
+        instructions.addStretch()
+
 
         layout = qg.QVBoxLayout()
+        layout.addLayout(instructions)
         layout.addLayout(layout_ops_sheet_sketch)
         layout.addLayout(number_of_parts_and_scale)
         layout.addLayout(xy_gap)
@@ -149,6 +182,12 @@ class Dialog(qg.QDialog):
         layout.addLayout(buttons)
         self.setLayout(layout)
 
+        # set text of all boxes
+        self.scale.setText(str(self.sc_tp))
+        self.N.setText(str(self.N_tp))
+        self.y_gap.setText(str(self.y_gap_tp))
+        self.x_gap.setText(str(self.x_gap_tp))
+        self.support_offset.setText(str(self.support_offset_tp))
 
     def build_sketch_links(self):
         try:
@@ -176,9 +215,12 @@ class Dialog(qg.QDialog):
         release_opref = opid
 
         # get bounding box from the sketch
-        sketch_id = self.sketch_to_tile.itemlist.selectedItems()[0].value.id
-        sketch_bounding_box = self.design.sketches[sketch_id].output_csg()[0].bounds # may break if multiple sketches
+        tmp_sketch_id = self.sketch_to_tile.itemlist.selectedItems()[0].value.id
+        sketch_bounding_box = self.design.sketches[tmp_sketch_id].output_csg()[0].bounds # may break if multiple sketches
         sketch_bounding_box = [geom/popupcad.csg_processing_scaling for geom in sketch_bounding_box]
+
+        sketch_id = self.sketch_to_tile.itemlist.selectedItems()[0].value
+
 
         N = int(self.N.text())
         scale = float(self.scale.text())
@@ -186,7 +228,8 @@ class Dialog(qg.QDialog):
         y_gap = float(self.y_gap.text())
         support_offset = float(self.support_offset.text())
 
-        return part_opref, release_opref, sheet_opref, sketch_bounding_box, N, scale, x_gap, y_gap, support_offset
+        return part_opref, release_opref, sheet_opref, sketch_bounding_box, N, scale, \
+               x_gap, y_gap, support_offset, sketch_id
 
 
 class TilePart(Operation2):
@@ -198,12 +241,14 @@ class TilePart(Operation2):
         self.editdata(*args)
         self.id = id(self)
 
-    def editdata(self,part_opref, release_opref, sheet_opref, sketch_bounding_box, N, scale, x_gap, y_gap, support_offset):
+    def editdata(self,part_opref, release_opref, sheet_opref, sketch_bounding_box, N, scale, x_gap, y_gap,
+                 support_offset, sketch_id):
         super(TilePart, self).editdata({},{},{})
         self.sheet_opref = sheet_opref
         self.release_opref = release_opref
         self.part_opref = part_opref
         self.sketch_bounding_box = sketch_bounding_box
+        self.sketch_id = sketch_id
         self.sc = scale
         self.N = N
         self.x_gap = x_gap
@@ -220,7 +265,8 @@ class TilePart(Operation2):
             self.sc,
             self.x_gap,
             self.y_gap,
-            self.support_offset)
+            self.support_offset,
+            self.sketch_id)
         new.id = self.id
         new.customname = self.customname
         return new
@@ -264,15 +310,6 @@ class TilePart(Operation2):
         # add sketch to sketch list
         design_copy.sketches[construction_geom_hinge.id] = construction_geom_hinge
 
-        # # make the sketchop
-        # construction_geom_sketchop_hinge = SimpleSketchOp({'sketch': [construction_geom_hinge.id]},
-        #                                     [layer.id for layer in design_copy.return_layer_definition().layers])
-        # construction_geom_sketchop_hinge.name = "ConstructionLine"
-        #
-        # # finally initialize sketch op in design_copy
-        # design_copy.addoperation(construction_geom_sketchop_hinge)
-        # construction_geom_sketchop_hinge.generate(design_copy)
-
         ######################## generate the external transform geometry in the sheet
 
         # center the locate line top left as origin
@@ -288,21 +325,20 @@ class TilePart(Operation2):
         max_num_cols = divmod(self.sketch_bounding_box[2] - self.sketch_bounding_box[0], width)[0]
         max_num_rows = divmod(self.sketch_bounding_box[3] - self.sketch_bounding_box[1], height)[0]
 
-        arrayed_reference_lines = []
+        if max_num_cols == 0 or max_num_rows == 0:
+            print('Cannot tile into this area')
+            design.remove_operation(new_web)
+            return Laminate()
 
         # check if can fit in one
         # if N <= max_num_rows*max_num_cols:
         rows = math.ceil(self.N / max_num_cols)
         cols = math.ceil(self.N / rows)          # spread across the two windows
 
-
-        # new_center = (-parts_bounding_box[0]/2, 2)
-        # tmp_geom = [(x + new_center[0], y + new_center[1]) for (x,y) in tmp_geom]
-
         upper_right_origin_bounding_box = (self.sketch_bounding_box[0], self.sketch_bounding_box[3])
 
         n_count = 0
-
+        arrayed_reference_lines = []
         for row in range(rows):
             for col in range(cols):
                 if n_count >= self.N or n_count >= max_num_rows*max_num_cols*2:
@@ -322,15 +358,6 @@ class TilePart(Operation2):
 
         # add sketch to sketch list
         design_copy.sketches[construction_geom_sheet.id] = construction_geom_sheet
-
-        # # make the sketchop
-        # construction_geom_sketchop_sheet = SimpleSketchOp({'sketch': [construction_geom_sheet.id]},
-        #                                     [layer.id for layer in design_copy.return_layer_definition().layers])
-        # construction_geom_sketchop_sheet.name = "ConstructionLine"
-
-        # # finally initialize sketch op in design_copy
-        # design_copy.addoperation(construction_geom_sketchop_sheet)
-        # construction_geom_sketchop_sheet.generate(design_copy)
 
         ######################## External transform the hinge onto the sheet construction line
 

--- a/popupcad_manufacturing_plugins/manufacturing/tilepart.py
+++ b/popupcad_manufacturing_plugins/manufacturing/tilepart.py
@@ -1,0 +1,427 @@
+# -*- coding: utf-8 -*-
+"""
+Contributed by Nick Gravish
+Email: gravish<at>seas.harvard.edu.
+Please see LICENSE for full license.
+"""
+
+
+# import os
+# import sys
+# import numpy as np
+import math
+import qt.QtGui as qg
+
+# from popupcad.filetypes.operationoutput import OperationOutput
+# import popupcad_manufacturing_plugins
+
+import popupcad
+from popupcad.filetypes.sketch import Sketch
+from popupcad_manufacturing_plugins.manufacturing.autoweb4 import AutoWeb4
+from popupcad.manufacturing.simplesketchoperation import SimpleSketchOp
+from popupcad.filetypes.genericshapes import GenericLine
+from popupcad.manufacturing.transform_internal import TransformInternal
+from popupcad.manufacturing.laminateoperation2 import LaminateOperation2
+from popupcad.filetypes.operation2 import Operation2
+from popupcad.manufacturing.multivalueoperation3 import MultiValueOperation3
+from popupcad.widgets.dragndroptree import DraggableTreeWidget
+from popupcad.widgets.listmanager import SketchListManager,SketchListViewer
+from popupcad.filetypes.operationoutput import OperationOutput
+
+class Dialog(qg.QDialog):
+
+    def __init__(self,design,prioroperations, tilepart = None):
+        super(Dialog, self).__init__()
+
+        if tilepart is not None:
+
+            self.sheet_opref_tp = tilepart.sheet_opref
+            self.part_opref_tp = tilepart.part_opref
+            self.sketch_bounding_box_tp = tilepart.sketch_bounding_box
+            self.sc_tp = tilepart.sc
+            self.N_tp = tilepart.N
+            self.x_gap_tp = tilepart.x_gap
+            self.y_gap_tp = tilepart.y_gap
+            self.support_offset_tp = tilepart.support_offset
+
+        else:
+            # define defaults
+            self.sheet_opref_tp = design.operations[1].id
+            self.part_opref_tp = design.operations[1].id
+            self.sketch_bounding_box_tp = [(0,0),(0,0)]
+            self.sc_tp = 1
+            self.N_tp = 10
+            self.x_gap_tp = 0
+            self.y_gap_tp = 0
+            self.support_offset_tp = 0
+
+        self.build_dialog(design, prioroperations)
+
+    def build_dialog(self, design, prioroperations):
+
+        self.prioroperations = prioroperations
+        self.design = design
+
+        #       operation/part | sketch to tile in | sheet to tile into
+        #                  'Number of parts', 'Scale'
+        #                       'x-gap', 'y-gap'
+        #                       'Support offset'
+
+        self.part = DraggableTreeWidget()
+        self.part.linklist(prioroperations)
+        self.part.setObjectName("Operation to tile")
+        # self.part.setCurrentItem(design.operation_index(self.part_opref_tp))
+
+        self.release = DraggableTreeWidget()
+        self.release.linklist(prioroperations)
+        self.release.setObjectName("Release cut (optional)")
+        # self.part.setCurrentItem(design.operation_index(self.part_opref_tp))
+
+        self.sketch_to_tile = SketchListManager(design,name = 'Sketch of tile area')
+
+        self.sheet = DraggableTreeWidget()
+        self.sheet.linklist(prioroperations)
+        self.sheet.setObjectName("Sheet to tile into")
+        # self.sheet.setCurrentItem(design.operation_index(self.sheet_opref_tp))
+
+        #       operation/part | sketch to tile in | sheet to tile into
+        layout_ops_sheet_sketch = qg.QHBoxLayout()
+        layout_ops_sheet_sketch.addWidget(self.part)
+        layout_ops_sheet_sketch.addWidget(self.release)
+        layout_ops_sheet_sketch.addWidget(self.sketch_to_tile)
+        layout_ops_sheet_sketch.addWidget(self.sheet)
+
+        #       'Number of parts', 'Scale'
+        number_of_parts_and_scale = qg.QHBoxLayout()
+
+        number_of_parts_and_scale.addStretch()
+        number_of_parts_and_scale.addWidget(qg.QLabel('Number of parts'))
+        self.N = qg.QLineEdit()
+        number_of_parts_and_scale.addWidget(self.N)
+        self.N.setText(str(self.N_tp))
+
+        number_of_parts_and_scale.addWidget(qg.QLabel('Scale'))
+        self.scale = qg.QLineEdit()
+        number_of_parts_and_scale.addWidget(self.scale)
+        number_of_parts_and_scale.addStretch()
+        self.scale.setText(str(self.sc_tp))
+
+        #                       'x-gap', 'y-gap'
+        xy_gap = qg.QHBoxLayout()
+        xy_gap.addStretch()
+
+        xy_gap.addWidget(qg.QLabel('X-gap'))
+        self.x_gap = qg.QLineEdit()
+        self.x_gap.setText(str(self.x_gap_tp))
+        xy_gap.addWidget(self.x_gap)
+
+        xy_gap.addWidget(qg.QLabel('Y-gap'))
+        self.y_gap = qg.QLineEdit()
+        self.y_gap.setText(str(self.y_gap_tp))
+        xy_gap.addWidget(self.y_gap)
+        xy_gap.addStretch()
+
+        s_offset = qg.QHBoxLayout()
+        s_offset.addStretch()
+        s_offset.addWidget(qg.QLabel('Support offset'))
+        self.support_offset = qg.QLineEdit()
+        self.support_offset.setText(str(self.support_offset_tp))
+        s_offset.addWidget(self.support_offset)
+        s_offset.addWidget(self.support_offset)
+        s_offset.addStretch()
+
+        # Button 1 and 2
+        buttons = qg.QHBoxLayout()
+        button1 = qg.QPushButton('Ok')
+        button1.clicked.connect(self.accept)
+        buttons.addWidget(button1)
+
+        button2 = qg.QPushButton('Cancel')
+        button2.clicked.connect(self.reject)
+        buttons.addWidget(button2)
+
+
+        layout = qg.QVBoxLayout()
+        layout.addLayout(layout_ops_sheet_sketch)
+        layout.addLayout(number_of_parts_and_scale)
+        layout.addLayout(xy_gap)
+        layout.addLayout(s_offset)
+        layout.addLayout(buttons)
+        self.setLayout(layout)
+
+
+    def build_sketch_links(self):
+        try:
+            sketch_links = {}
+            sketch_links['sketch_from']=[self.sketch_to_tile.itemlist.selectedItems()[0].value.id]
+            return sketch_links
+        except IndexError:
+            return None
+
+    def acceptdata(self):
+
+        # get operation reference for part
+        ii, jj = self.part.currentIndeces2()[0]
+        opid = self.design.operations[ii].id
+        part_opref = opid
+
+        # get operation reference for sheet
+        ii, jj = self.sheet.currentIndeces2()[0]
+        opid = self.design.operations[ii].id
+        sheet_opref = opid
+
+        # get operation reference for release
+        ii, jj = self.release.currentIndeces2()[0]
+        opid = self.design.operations[ii].id
+        release_opref = opid
+
+        # get bounding box from the sketch
+        sketch_id = self.sketch_to_tile.itemlist.selectedItems()[0].value.id
+        sketch_bounding_box = self.design.sketches[sketch_id].output_csg()[0].bounds # may break if multiple sketches
+        sketch_bounding_box = [geom/popupcad.csg_processing_scaling for geom in sketch_bounding_box]
+
+        N = int(self.N.text())
+        scale = float(self.scale.text())
+        x_gap = float(self.x_gap.text())
+        y_gap = float(self.y_gap.text())
+        support_offset = float(self.support_offset.text())
+
+        return part_opref, release_opref, sheet_opref, sketch_bounding_box, N, scale, x_gap, y_gap, support_offset
+
+
+class TilePart(Operation2):
+    name = 'TiledPart'
+    show = []
+
+    def __init__(self, *args):
+        super(TilePart, self).__init__()
+        self.editdata(*args)
+        self.id = id(self)
+
+    def editdata(self,part_opref, release_opref, sheet_opref, sketch_bounding_box, N, scale, x_gap, y_gap, support_offset):
+        super(TilePart, self).editdata({},{},{})
+        self.sheet_opref = sheet_opref
+        self.release_opref = release_opref
+        self.part_opref = part_opref
+        self.sketch_bounding_box = sketch_bounding_box
+        self.sc = scale
+        self.N = N
+        self.x_gap = x_gap
+        self.y_gap = y_gap
+        self.support_offset = support_offset
+
+    def copy(self):
+        new = type(self)(
+            self.part_opref,
+            self.release_opref,
+            self.sheet_opref,
+            self.sketch_bounding_box,
+            self.N,
+            self.sc,
+            self.x_gap,
+            self.y_gap,
+            self.support_offset)
+        new.id = self.id
+        new.customname = self.customname
+        return new
+
+
+    # finally initialize sketch op in design
+    def operate(self, design):
+
+        design_copy = design
+        # design_copy.reprocessoperations()
+
+        part_to_insert = design_copy.operations[design_copy.operation_index(self.part_opref)]
+        sheet_to_insert_into = design_copy.operations[design_copy.operation_index(self.sheet_opref)]
+        release_to_insert_into = design_copy.operations[design_copy.operation_index(self.release_opref)]
+
+        # build the op_links, then auto make the operation
+        op = part_to_insert
+        op_ref = op.id
+        op_links = {'parent': [(op_ref, op.getoutputref())]}
+
+        new_web = AutoWeb4(op_links,[self.support_offset,0],MultiValueOperation3.keepout_types.laser_keepout)
+        new_web.setcustomname(op.name)
+
+        # support = OperationOutput(new_web.output[1], "support", self)
+
+        design_copy.addoperation(new_web)
+        new_web.generate(design_copy)
+
+        ######################## generate the same size construction line somewhere in the sheet file
+
+        # get geom for line
+        parts_bounding_box = new_web.output[1].generic_laminate().getBoundingBox()
+        # parts_bounding_box  = support.generic_laminate().getBoundingBox()
+
+        # make the sketch
+        construction_geom_hinge = Sketch.new()
+        tmp_geom = [(parts_bounding_box[0],parts_bounding_box[1]), (parts_bounding_box[0],parts_bounding_box[3])]
+        construction_line = GenericLine.gen_from_point_lists(tmp_geom,[],construction=False)
+        construction_geom_hinge.addoperationgeometries([construction_line])
+
+        # add sketch to sketch list
+        design_copy.sketches[construction_geom_hinge.id] = construction_geom_hinge
+
+        # # make the sketchop
+        # construction_geom_sketchop_hinge = SimpleSketchOp({'sketch': [construction_geom_hinge.id]},
+        #                                     [layer.id for layer in design_copy.return_layer_definition().layers])
+        # construction_geom_sketchop_hinge.name = "ConstructionLine"
+        #
+        # # finally initialize sketch op in design_copy
+        # design_copy.addoperation(construction_geom_sketchop_hinge)
+        # construction_geom_sketchop_hinge.generate(design_copy)
+
+        ######################## generate the external transform geometry in the sheet
+
+        # center the locate line top left as origin
+        position_hinge = (-tmp_geom[0][0],-tmp_geom[0][1])
+        locate_lines = [(x + position_hinge[0], y + position_hinge[1]) for (x,y) in tmp_geom]
+
+        # lets make 4x4
+        width = (parts_bounding_box[2] - parts_bounding_box[0])*self.sc + self.x_gap
+        height = (parts_bounding_box[3] - parts_bounding_box[1])*self.sc + self.y_gap
+
+
+        # check if will all fit in one window, if not fill first and check if remainder will fit in second window
+        max_num_cols = divmod(self.sketch_bounding_box[2] - self.sketch_bounding_box[0], width)[0]
+        max_num_rows = divmod(self.sketch_bounding_box[3] - self.sketch_bounding_box[1], height)[0]
+
+        arrayed_reference_lines = []
+
+        # check if can fit in one
+        # if N <= max_num_rows*max_num_cols:
+        rows = math.ceil(self.N / max_num_cols)
+        cols = math.ceil(self.N / rows)          # spread across the two windows
+
+
+        # new_center = (-parts_bounding_box[0]/2, 2)
+        # tmp_geom = [(x + new_center[0], y + new_center[1]) for (x,y) in tmp_geom]
+
+        upper_right_origin_bounding_box = (self.sketch_bounding_box[0], self.sketch_bounding_box[3])
+
+        n_count = 0
+
+        for row in range(rows):
+            for col in range(cols):
+                if n_count >= self.N or n_count >= max_num_rows*max_num_cols*2:
+                    break
+
+                newx = upper_right_origin_bounding_box[0] + locate_lines[0][0] + col*width
+                newy = upper_right_origin_bounding_box[1] - locate_lines[1][1] - row*height
+
+                arrayed_reference_lines.append([(newx, newy), (newx, newy + height)])
+
+                n_count = n_count + 1
+
+        construction_geom_sheet = Sketch.new()
+        construction_line = [GenericLine.gen_from_point_lists(line,[],construction=False) for
+                     line in arrayed_reference_lines]
+        construction_geom_sheet.addoperationgeometries(construction_line)
+
+        # add sketch to sketch list
+        design_copy.sketches[construction_geom_sheet.id] = construction_geom_sheet
+
+        # # make the sketchop
+        # construction_geom_sketchop_sheet = SimpleSketchOp({'sketch': [construction_geom_sheet.id]},
+        #                                     [layer.id for layer in design_copy.return_layer_definition().layers])
+        # construction_geom_sketchop_sheet.name = "ConstructionLine"
+
+        # # finally initialize sketch op in design_copy
+        # design_copy.addoperation(construction_geom_sketchop_sheet)
+        # construction_geom_sketchop_sheet.generate(design_copy)
+
+        ######################## External transform the hinge onto the sheet construction line
+
+        # # insert hinge into sheet as subdesign
+        # sheet.subdesigns[hinge.id] = hinge
+
+        # # make design links
+        operation_links = {}
+        operation_links['from'] = [(part_to_insert.id,0)]
+
+        sketch_links = {}
+        sketch_links['sketch_to'] = [construction_geom_sheet.id]
+        sketch_links['sketch_from'] = [construction_geom_hinge.id]
+
+        insert_part = TransformInternal(sketch_links, operation_links, 'scale', 'scale', 0, False, 1., 1.)
+        insert_part.customname = 'Inserted part'
+
+        design_copy.addoperation(insert_part)
+        insert_part.generate(design_copy)
+        insert_part_id = design_copy.operations[-1].id # save for later
+
+        ######################## External transform the web.sheet to the construction line
+
+        # # make design links
+        operation_links = {}
+        operation_links['from'] = [(new_web.id,1)]
+
+        sketch_links = {}
+        sketch_links['sketch_to'] = [construction_geom_sheet.id]
+        sketch_links['sketch_from'] = [construction_geom_hinge.id]
+
+        insert_webs = TransformInternal(sketch_links, operation_links, 'scale', 'scale', 0, False, 1., 1.)
+        insert_webs.customname = 'Inserted part webs'
+
+        design_copy.addoperation(insert_webs)
+        insert_webs.generate(design_copy)
+
+        ######################## Remove web.sheet from sheet, union external transform + generateed sheet with hole + web
+        # first the difference
+        # link 1 is the sheet
+        sheet_with_hole = LaminateOperation2({'unary': [(sheet_to_insert_into.id,0)], 'binary': [(insert_webs.id,0)]},'difference')
+        sheet_with_hole.customname = 'Sheet with hole'
+        design_copy.addoperation(sheet_with_hole)
+        sheet_with_hole.generate(design_copy)
+
+        sheet_with_part = LaminateOperation2({'unary': [(sheet_with_hole.id,0), (insert_part_id,0)],
+                                      'binary':[]},'union')
+
+        sheet_with_part.customname = 'First pass cuts'
+        design_copy.addoperation(sheet_with_part)
+        sheet_with_part.generate(design_copy)
+
+        # ######################## Make release cut laminate operation
+
+
+        operation_links = {}
+        operation_links['from'] = [(release_to_insert_into.id,0)]
+
+        sketch_links = {}
+        sketch_links['sketch_to'] = [construction_geom_sheet.id]
+        sketch_links['sketch_from'] = [construction_geom_hinge.id]
+
+        insert_release = TransformInternal(sketch_links, operation_links, 'scale', 'scale', 0, False, 1., 1.)
+
+        design.addoperation(insert_release)
+        insert_release.generate(design)
+
+        ######################################### prepare outputs
+
+        # delete the intermediate layers
+        design.remove_operation(sheet_with_hole)
+        design.remove_operation(insert_webs)
+        design.remove_operation(insert_part)
+        design.remove_operation(new_web)
+        design.remove_operation(sheet_with_part)
+        design.remove_operation(insert_release)
+
+        self.output = [OperationOutput(sheet_with_part.output[0].csg, 'FirstCuts', self),
+                       OperationOutput(sheet_with_part.output[0].csg, 'FirstCuts', self),
+                       OperationOutput(insert_release.output[0].csg, 'Release', self)]
+
+        return sheet_with_part.output[0].csg
+
+        # probably a memory leak here not deleting design_copy
+
+
+    @classmethod
+    def buildnewdialog(cls, design, currentop):
+        dialog = Dialog(design, design.operations, None)
+        return dialog
+
+    def buildeditdialog(self, design):
+        dialog = Dialog(design,design.operations, self)
+        return dialog

--- a/popupcad_manufacturing_plugins/manufacturing/tilepart.py
+++ b/popupcad_manufacturing_plugins/manufacturing/tilepart.py
@@ -46,8 +46,8 @@ class Dialog(qg.QDialog):
 
         else:
             # define defaults
-            self.sheet_opref_tp = design.operations[1].id
-            self.part_opref_tp = design.operations[1].id
+            self.sheet_opref_tp = None
+            self.part_opref_tp = None
             self.sketch_bounding_box_tp = [(0,0),(0,0)]
             self.sc_tp = 1
             self.N_tp = 10


### PR DESCRIPTION
Dan, 

Take a look at these two additions and let me know if they are suitable or need more work. 

This PR adds to manufacturing widgets to auto generate a full heat press alignment skeleton (with default sizes for the robobee size layup but those can be changed in the dialog box). This is meant so you don't have to constantly redraw layup geometry, and it adds layer specific windows for focusing and layer identification. 

The second widget adds a tilepart function which will tile a supported part and release cut into the a sheet geometry (like the layup skeleton you can create from first function). You select the bounding box defined by a sketch to tile into, and the number of parts, some spacing geometry, etc. 

I think this still needs some testing before fully being integrated but maybe you want to take a look and play around a little bit? 

Nick
